### PR TITLE
Print error message to stdout for missing zsh

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -24,7 +25,8 @@ func newShell(stdout chan<- rune) Shell {
 
 	ptmx, err := pty.Start(cmd)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	shell := Shell{


### PR DESCRIPTION
Without a debug log file set the logger is set to log to `iotuil.Discard`. This seems to be ok in most cases, but was a bit confusing for me as I was missing `zsh` and the executable just exited without an error message. 

There are a few other `log.Fatal` cases in the codebase that might be worth some additional scrutiny. Possibly the one in `(s *Shell)handleStdin`, among others. 