### PR TITLE
Get shell from env var if available

### DIFF
--- a/pane.go
+++ b/pane.go
@@ -49,6 +49,9 @@ type Pane struct {
 }
 
 func getShellPath() string {
+	if shell := os.Getenv("SHELL"); shell != "" {
+		return shell
+	}
 	username := os.Getenv("USER")
 
 	file, err := os.Open("/etc/passwd")


### PR DESCRIPTION
In modern MacOS account information like shell is not present in
/etc/passwd for your user account by default. It's in the Directory
Service.
Commonly MacOS and Linux have the SHELL env variable set for login
shells.
This change makes the SHELL env variable the preferred shell discovery
mechanism and falls back to /etc/passwd if it's unset.