### PR TITLE
implement Reverse Index (fixes nano scrolling)

### DIFF
--- a/ecma48/parser.go
+++ b/ecma48/parser.go
@@ -244,6 +244,12 @@ func (p *Parser) stateGround(r rune) {
 
 func (p *Parser) stateEscape(r rune) {
 	switch {
+	case r == '7':
+		p.out <- p.wrap(SCOSC{})
+		p.state = stateGround
+	case r == '8':
+		p.out <- p.wrap(SCORC{})
+		p.state = stateGround
 	case strings.Contains("DEHMNOPVWXZ[\\]^_", string(r)):
 		p.anywhere(r + 0x40)
 	case 0x30 <= r && r <= 0x4F || 0x51 <= r && r <= 0x57:

--- a/vterm/stdout.go
+++ b/vterm/stdout.go
@@ -81,8 +81,7 @@ func (v *VTerm) ProcessStdout(input *bufio.Reader) {
 					v.shiftCursorY(1)
 				}
 			case ecma48.RI:
-				fmt.Println(v.Cursor.Y, v.scrollingRegion.top)
-				if v.Cursor.Y == v.scrollingRegion.top-1 {
+				if v.Cursor.Y == v.scrollingRegion.top {
 					v.scrollDown(1)
 				} else {
 					v.shiftCursorY(-1)

--- a/vterm/stdout.go
+++ b/vterm/stdout.go
@@ -80,6 +80,13 @@ func (v *VTerm) ProcessStdout(input *bufio.Reader) {
 				} else {
 					v.shiftCursorY(1)
 				}
+			case ecma48.RI:
+				fmt.Println(v.Cursor.Y, v.scrollingRegion.top)
+				if v.Cursor.Y == v.scrollingRegion.top-1 {
+					v.scrollDown(1)
+				} else {
+					v.shiftCursorY(-1)
+				}
 			case ecma48.CarriageReturn:
 				v.setCursorX(0)
 			case ecma48.Tab:


### PR DESCRIPTION
Implements Reverse Index, which is pretty much a backward newline. Fixes scrolling in `nano`

https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences