### PR TITLE
properly handle errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -207,7 +207,7 @@ func launchServer(sessionName string) (sessionID string) {
 	os.MkdirAll(dir, 0755)                                              // FIXME perms
 	ioutil.WriteFile(path.Join(dir, "name"), []byte(sessionName), 0777) // FIXME perms
 
-	readySocket, err := net.Listen("unix", path.Join(dir, "ready.sock"))
+	readySocket, err := net.Listen("unix", path.Join(dir, "booted.sock"))
 	if err != nil {
 		panic(err)
 	}
@@ -226,8 +226,14 @@ func launchServer(sessionName string) (sessionID string) {
 		panic(err)
 	}
 
-	readySocket.Accept()
-	os.Remove(path.Join(dir, "ready.sock"))
+	conn, _ := readySocket.Accept()
+	logs, _ := ioutil.ReadAll(conn)
+	if len(logs) > 0 {
+		fmt.Print(string(logs))
+		os.Exit(1)
+	}
+
+	os.Remove(path.Join(dir, "booted.sock"))
 
 	return sessionID
 }


### PR DESCRIPTION
Server failures no longer leave 3mux in a broken state. More specifically:
1. Dead servers are no longer shown in the session list
2. Failed server boot (e.g. panic while retrieving config file) no longer results in a hang

Server error diagnostics are also printed by the client after 3mux exits :-)