### PR TITLE
report errors while detached

### DIFF
--- a/attach.go
+++ b/attach.go
@@ -23,6 +23,22 @@ func attach(sessionID string) {
 		fmt.Print(shutdownMessage)
 	}()
 
+	// check if that session has crashed
+	if _, err := os.Stat(path.Join(dir, "crash")); err == nil {
+		logPath := path.Join(threemuxDir, sessionID, "crash")
+		diagnostics, _ := ioutil.ReadFile(logPath)
+
+		// delete the old session data so we don't see it again
+		os.RemoveAll(path.Join(threemuxDir, sessionID))
+
+		fmt.Printf("\x1b[mThat session has crashed :-(\n")
+		fmt.Printf("Here's what I know:\n\n")
+		fmt.Print(string(diagnostics))
+		fmt.Println()
+
+		return
+	}
+
 	oldState, err := terminal.MakeRaw(0)
 	if err != nil {
 		panic(err)

--- a/attach.go
+++ b/attach.go
@@ -15,6 +15,13 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+const errorReportFormat = `That session has crashed :-(
+
+Here's what I know:
+
+%s
+`
+
 func attach(sessionID string) {
 	dir := path.Join(threemuxDir, sessionID)
 
@@ -31,10 +38,7 @@ func attach(sessionID string) {
 		// delete the old session data so we don't see it again
 		os.RemoveAll(path.Join(threemuxDir, sessionID))
 
-		fmt.Printf("\x1b[mThat session has crashed :-(\n")
-		fmt.Printf("Here's what I know:\n\n")
-		fmt.Print(string(diagnostics))
-		fmt.Println()
+		fmt.Printf("\x1b[m"+errorReportFormat, string(diagnostics))
 
 		return
 	}

--- a/attach.go
+++ b/attach.go
@@ -21,7 +21,6 @@ func attach(sessionID string) {
 	var shutdownMessage string
 	defer func() {
 		fmt.Print(shutdownMessage)
-		os.RemoveAll(dir)
 	}()
 
 	oldState, err := terminal.MakeRaw(0)

--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ func main() {
 }
 
 func detach(parentSessionID string) {
-	net.Dial("unix", path.Join(threemuxDir, parentSessionID, "detach-client.sock"))
+	net.Dial("unix", path.Join(threemuxDir, parentSessionID, "shutdown.sock"))
 }
 
 func findSession(sessionName string) (sessionID string, err error) {

--- a/serve.go
+++ b/serve.go
@@ -51,9 +51,9 @@ func serve(sessionID string) {
 		} else {
 			// tell the client to gracefully detach
 			net.Dial("unix", path.Join(dir, clientExitSock))
-		}
 
-		os.RemoveAll(dir)
+			os.RemoveAll(dir)
+		}
 	}()
 
 	config := loadOrGenerateConfig()
@@ -103,6 +103,7 @@ func serve(sessionID string) {
 	})
 
 	go func() {
+		defer recover()
 		detachSocket, err := net.Listen("unix", path.Join(dir, "detach-server.sock"))
 		if err != nil {
 			panic(err)

--- a/serve.go
+++ b/serve.go
@@ -43,11 +43,11 @@ func serve(sessionID string) {
 			conn, err := net.Dial("unix", path.Join(dir, clientExitSock))
 			if err == nil {
 				conn.Write([]byte(diagnostics))
-			} else {
-				timestamp := time.Now().UTC().Format(time.RFC3339)
-				diagnostics = fmt.Sprintf("At %s...\n\n%s", timestamp, diagnostics)
-				ioutil.WriteFile(path.Join(dir, "crash"), []byte(diagnostics), 0666)
 			}
+
+			timestamp := time.Now().UTC().Format(time.RFC3339)
+			diagnostics = fmt.Sprintf("At %s...\n\n%s", timestamp, diagnostics)
+			ioutil.WriteFile(path.Join(dir, "crash"), []byte(diagnostics), 0666)
 		} else {
 			// tell the client to gracefully detach
 			net.Dial("unix", path.Join(dir, clientExitSock))


### PR DESCRIPTION
Depends on #85.

`main.go` eventually needs to be refactored. In this PR:
- errors are logged in `$SESSION_DIR/crash`
- when the user 

Best way to test this is by applying the following diff to `vterm/stdout.go`

```diff
diff --git a/vterm/stdout.go b/vterm/stdout.go
index e6edf7c..7f49250 100644
--- a/vterm/stdout.go
+++ b/vterm/stdout.go
@@ -2,8 +2,10 @@ package vterm

 import (
        "bufio"
+       "fmt"
        "log"
        "sync/atomic"
+       "time"

        "github.com/aaronjanse/3mux/ecma48"
 )
@@ -64,6 +66,10 @@ func (v *VTerm) ProcessStdout(input *bufio.Reader) {
                                break
                        }

+                       if time.Now().Second() == 0 {
+                               panic(fmt.Errorf("FORCED"))
+                       }
+
                        // log.Printf(":: %q", output.Raw)

                        switch x := output.Parsed.(type) {
```

This is a draft PR until I test it a little more later tonight