### PR TITLE
cleaner boot and error handling

### DIFF
--- a/attach.go
+++ b/attach.go
@@ -41,7 +41,6 @@ func attach(sessionInfo SessionInfo) error {
 	fdConn, err := net.Dial("unix", sessionInfo.fdPath)
 	if err != nil {
 		return fmt.Errorf("Although the server socket exists, connection to it failed: %s", err.Error())
-
 	}
 	fConn, err := fdConn.(*net.UnixConn).File()
 	if err != nil {

--- a/attach.go
+++ b/attach.go
@@ -89,7 +89,7 @@ func waitForFdSock(sessionInfo SessionInfo) error {
 		time.Sleep(time.Millisecond * 50)
 
 		if i == 0 {
-			return fmt.Errorf("server failed to boot")
+			return fmt.Errorf("Server failed to boot in 0.5s")
 		}
 	}
 	return nil

--- a/attach.go
+++ b/attach.go
@@ -66,7 +66,6 @@ func attach(sessionInfo SessionInfo) {
 		os.Exit(1)
 	}
 
-	// defer net.Dial("unix", path.Join(dir, "detach-server.sock"))
 	rights := syscall.UnixRights(int(os.Stdin.Fd()), int(os.Stdout.Fd()))
 	err = syscall.Sendmsg(int(fConn.Fd()), nil, rights, nil, 0)
 	if err != nil {

--- a/attach.go
+++ b/attach.go
@@ -40,7 +40,7 @@ func attach(sessionInfo SessionInfo) error {
 
 	fdConn, err := net.Dial("unix", sessionInfo.fdPath)
 	if err != nil {
-		return fmt.Errorf("Although the server socket exists, connection to it failed: %s", err.Error())
+		return fmt.Errorf("Although the server socket exists, connection to it failed: %s", err)
 	}
 	fConn, err := fdConn.(*net.UnixConn).File()
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -63,7 +63,7 @@ func loadOrGenerateConfig() (CompiledConfig, error) {
 				return CompiledConfig{}, fmt.Errorf("Failed to read config at `%s`: %s", configPath, err)
 			}
 		} else {
-			return CompiledConfig{}, fmt.Errorf("Found in home but not XDG? %s", err.Error())
+			return CompiledConfig{}, fmt.Errorf("Found in home but not XDG? %s", err)
 		}
 	} else {
 		data, err := ioutil.ReadFile(xdgConfigPath)

--- a/config.go
+++ b/config.go
@@ -111,7 +111,7 @@ func compileConfig(user UserConfig) (CompiledConfig, error) {
 			}
 			delete(mode, "mode-start")
 		} else {
-			return CompiledConfig{}, errors.New("Could not find starter for mode " + modeName)
+			return CompiledConfig{}, fmt.Errorf("Could not find starter for mode %s", modeName)
 		}
 
 		mode := castMapInterface(mode)

--- a/ecma48/color.go
+++ b/ecma48/color.go
@@ -29,5 +29,5 @@ func (c *Color) ToANSI(bg bool) string {
 		)
 	default:
 		panic(fmt.Sprintf("Unexpected ColorMode: %v", c.ColorMode))
-	}	
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/mattn/go-runewidth v0.0.9
 	github.com/npat-efault/poller v2.0.0+incompatible
+	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/sevlyar/go-daemon v0.1.5
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 	golang.org/x/text v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/Qd
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/npat-efault/poller v2.0.0+incompatible h1:jtTdXWKgN5kDK41ts8hoY1rvTEi0K08MTB8/bRO9MqE=
 github.com/npat-efault/poller v2.0.0+incompatible/go.mod h1:lni01B89P8PtVpwlAhdhK1niN5rPkDGGpGGgBJzpSgo=
+github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
+github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/sevlyar/go-daemon v0.1.5 h1:Zy/6jLbM8CfqJ4x4RPr7MJlSKt90f00kNM1D401C+Qk=
 github.com/sevlyar/go-daemon v0.1.5/go.mod h1:6dJpPatBT9eUwM5VCw9Bt6CdX9Tk6UWvhW3MebLDRKE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/help.go
+++ b/help.go
@@ -15,6 +15,7 @@ USAGE:
     3mux attach <name>  Attach to a session
     3mux detach			Detach from the current session
     3mux new <name>     Create a new session
+    3mux kill <name>    Kill a session
 
 SHORTCUTS:
 	Alt+N/Alt+Enter  Create new pane

--- a/help.go
+++ b/help.go
@@ -14,10 +14,8 @@ USAGE:
     3mux ls             List session names (has alias '3mux ps')
     3mux attach <name>  Attach to a session
     3mux detach			Detach from the current session
+    3mux new <name>     Create a new session
 
-FLAGS:
-	-h, --help       Prints help information
-	
 SHORTCUTS:
 	Alt+N/Alt+Enter  Create new pane
 	Alt+Shift+Q		 Close pane

--- a/main.go
+++ b/main.go
@@ -249,7 +249,7 @@ func main() {
 	case "detach":
 		if parentSessionID == "" {
 			fmt.Println("Must be within session to detach")
-			return
+			os.Exit(1)
 		}
 		detach(parentSessionID)
 	default:

--- a/main.go
+++ b/main.go
@@ -138,7 +138,6 @@ func main() {
 	case "new":
 		if parentSessionID != "" {
 			refuseNesting()
-			os.Exit(1)
 		}
 		if len(os.Args) != 3 {
 			fmt.Println("Usage: 3mux new <name>")
@@ -180,7 +179,6 @@ func main() {
 	case "attach":
 		if parentSessionID != "" {
 			refuseNesting()
-			os.Exit(1)
 		}
 		if len(os.Args) != 3 {
 			fmt.Println("Usage: 3mux attach <name>")
@@ -351,6 +349,7 @@ func findSession(sessionName string) (sessionInfo SessionInfo, found bool, err e
 func refuseNesting() {
 	fmt.Println("Refusing to run 3mux inside itself.")
 	fmt.Println("If you want to do so anyway, `unset THREEMUX`.")
+	os.Exit(1)
 }
 
 func defaultPrompt() (sessionName string, isNew bool) {

--- a/main.go
+++ b/main.go
@@ -219,16 +219,18 @@ func main() {
 
 		_, err = net.Dial("unix", sessionInfo.killServerPath)
 		if err != nil {
-			fmt.Println("Killing the server failed.")
-			fmt.Println("To create a new session with this name:")
-			fmt.Println("1. Ensure there are no unwanted 3mux processes running")
-			fmt.Printf("2. Run `rm -rf %s`\n", sessionInfo.path)
+			fmt.Println("Killing the server failed. Maybe one isn't running?")
 			os.Exit(1)
 		}
 
 		err = os.RemoveAll(sessionInfo.path)
 		if err != nil {
 			fmt.Printf("Failed to remove metadata directory `%s`: %s\n", sessionInfo.path, err)
+			fmt.Println("")
+			fmt.Println("To create a new session with this name:")
+			fmt.Println("1. Ensure there are no unwanted 3mux processes running")
+			fmt.Printf("2. Run `rm -rf %s`\n\n", sessionInfo.path)
+			fmt.Printf("Please also report this to %s\n", BUG_REPORT_URL)
 			os.Exit(1)
 		}
 		fmt.Println("Session sucessfully killed.")

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 			for choice != "y" && choice != "n" {
 				fmt.Print("Would you like to detach? [Y/n] ")
 				fmt.Scanf("%s", &choice)
-				choice = strings.ToLower(choice)
+				choice = strings.TrimSpace(strings.ToLower(choice))
 				if choice == "" {
 					choice = "y"
 				}

--- a/main.go
+++ b/main.go
@@ -125,7 +125,12 @@ func main() {
 		err = serve(sessionInfo)
 		if err == nil {
 			log.Println("Exiting cleanly...")
-			os.RemoveAll(sessionInfo.path)
+			err := os.RemoveAll(sessionInfo.path)
+			if err != nil {
+				log.Printf("Failed to remove metadata directory `%s`: %s\n", sessionInfo.path, err)
+				log.Printf("It can be removed manually with `rm -rf %s`, although the above error "+
+					"message is likely relevant.", sessionInfo.path)
+			}
 		} else {
 			log.Println(err)
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -130,6 +130,7 @@ func main() {
 				log.Printf("Failed to remove metadata directory `%s`: %s\n", sessionInfo.path, err)
 				log.Printf("It can be removed manually with `rm -rf %s`, although the above error "+
 					"message is likely relevant.", sessionInfo.path)
+				os.Exit(1)
 			}
 		} else {
 			log.Println(err)

--- a/main.go
+++ b/main.go
@@ -193,7 +193,7 @@ func main() {
 		}
 		err = attach(sessionInfo)
 		if err != nil {
-			fmt.Println(err.Error())
+			fmt.Println(err)
 			fmt.Println("See server-side logs at", path.Join(sessionInfo.path, "logs-server.txt"))
 			fmt.Printf("To manually kill this session, run `3mux kill %s`\n", sessionName)
 			os.Exit(1)
@@ -309,7 +309,7 @@ func initializeSession(sessionName string) SessionInfo {
 		if err != nil {
 			fmt.Printf(
 				"Session clean-up failed. Error while removing directory `%s`: %s",
-				sessionPath, err.Error(),
+				sessionPath, err,
 			)
 		}
 		fmt.Printf("Please report this to %s\n", BUG_REPORT_URL)

--- a/main.go
+++ b/main.go
@@ -213,6 +213,7 @@ func main() {
 			fmt.Println("Failed to find session with name:", sessionName)
 			os.Exit(1)
 		}
+
 		_, err = net.Dial("unix", sessionInfo.killServerPath)
 		if err != nil {
 			fmt.Println("Killing the server failed.")
@@ -220,9 +221,14 @@ func main() {
 			fmt.Println("1. Ensure there are no unwanted 3mux processes running")
 			fmt.Printf("2. Run `rm -rf %s`\n", sessionInfo.path)
 			os.Exit(1)
-		} else {
-			fmt.Println("Session sucessfully killed.")
 		}
+
+		err = os.RemoveAll(sessionInfo.path)
+		if err != nil {
+			fmt.Printf("Failed to remove metadata directory `%s`: %s\n", sessionInfo.path, err)
+			os.Exit(1)
+		}
+		fmt.Println("Session sucessfully killed.")
 	case "ls", "ps":
 		children, err := ioutil.ReadDir(threemuxDir)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func main() {
 		}
 
 		name, isNew := defaultPrompt()
-		if name == "" {
+		if name == "" { // only happens upon Ctrl-C
 			os.Exit(1)
 		}
 		if isNew {
@@ -355,6 +355,7 @@ func refuseNesting() {
 	os.Exit(1)
 }
 
+// returns empty name upon Ctrl-C
 func defaultPrompt() (sessionName string, isNew bool) {
 	os.MkdirAll(threemuxDir, 0755)
 	children, err := ioutil.ReadDir(threemuxDir)

--- a/main.go
+++ b/main.go
@@ -226,8 +226,7 @@ func main() {
 
 		err = os.RemoveAll(sessionInfo.path)
 		if err != nil {
-			fmt.Printf("Failed to remove metadata directory `%s`: %s\n", sessionInfo.path, err)
-			fmt.Println("")
+			fmt.Printf("Failed to remove metadata directory `%s`: %s\n\n", sessionInfo.path, err)
 			fmt.Println("To create a new session with this name:")
 			fmt.Println("1. Ensure there are no unwanted 3mux processes running")
 			fmt.Printf("2. Run `rm -rf %s`\n\n", sessionInfo.path)

--- a/pane/pane.go
+++ b/pane/pane.go
@@ -82,8 +82,7 @@ func (t *Pane) SetRenderRect(fullscreen bool, x, y, w, h int) {
 				if r := recover(); r != nil {
 					t.Dead = true
 					t.OnDeath(fmt.Errorf("%s\n%s",
-						r.(error).Error(),
-						debug.Stack(),
+						r.(error), debug.Stack(),
 					))
 				}
 			}()

--- a/serve.go
+++ b/serve.go
@@ -20,7 +20,7 @@ func serve(sessionInfo SessionInfo) error {
 
 	config, err := loadOrGenerateConfig()
 	if err != nil {
-		return fmt.Errorf("Failed to load or generate config: %s", err.Error())
+		return fmt.Errorf("Failed to load or generate config: %s", err)
 	}
 
 	renderer := render.NewRenderer(-1)
@@ -39,7 +39,7 @@ func serve(sessionInfo SessionInfo) error {
 		func(err error) {
 			go func() {
 				if err != nil {
-					shutdown <- fmt.Errorf("%s\n%s", err.Error(), debug.Stack())
+					shutdown <- fmt.Errorf("%s\n%s", err, debug.Stack())
 				} else {
 					shutdown <- nil
 				}

--- a/vterm/ops.go
+++ b/vterm/ops.go
@@ -243,7 +243,7 @@ func (v *VTerm) forceRedrawWindow() {
 							X: v.x + x, Y: v.y + y + v.ScrollbackPos, Style: ecma48.Style{},
 						},
 					}
-					v.renderer.HandleCh(ch)					
+					v.renderer.HandleCh(ch)
 				}
 
 			}


### PR DESCRIPTION
Changes:
- much more code re-use, made possible by writing to `os.Args` (is this okay?)
- panics are no longer used everywhere to report errors during the boot process
- many more error checks have been added
- new `kill` command for users dealing with broken sessions
- new `new` command for creating sessions
- session IDs are now UUIDs
- server logs are written in `$TMPDIR/3mux/$UUID/logs-server.txt`
- unified constant strings for special paths in `$TMPDIR/3mux/$UUID`

Before the next release, I'd like to make a PR to fix some panics found by fuzzing `wm` and `vterm`.