### PR TITLE
fix coloring in bash :tada:

### DIFF
--- a/vterm/stdout.go
+++ b/vterm/stdout.go
@@ -60,10 +60,6 @@ func (v *VTerm) ProcessStdout(input *bufio.Reader) {
 				v.useFastRefresh()
 			}
 
-			if len(output.Raw) == 0 {
-				break
-			}
-
 			// log.Printf(":: %q", output.Raw)
 
 			switch x := output.Parsed.(type) {


### PR DESCRIPTION
`ecma48` clears the `Raw` data buffer when it emits an event. Bash sets multiple styles/colors in the same commend. So, the 2nd+ events emitted for these multi-style sequences had an empty `Raw` data list, causing them to be ignored by vterm.

I think the original reason for skipping events with empty Raw data was for a bug that was fixed by rewriting the ecma48
parser.