### PR TITLE
Reduce large amount of unneeded writing to stdout

### DIFF
--- a/render/cursor.go
+++ b/render/cursor.go
@@ -26,11 +26,13 @@ func deltaMarkup(fromCur, toCur ecma48.Cursor) string {
 	to := toCur.Style
 	from := fromCur.Style
 
-	if to.Bg.ColorMode != from.Bg.ColorMode || to.Bg.Code != from.Bg.Code {
+	differentBgCode := (to.Bg.ColorMode != ecma48.ColorNone || true) && to.Bg.Code != from.Bg.Code
+	if to.Bg.ColorMode != from.Bg.ColorMode || differentBgCode {
 		out += to.Bg.ToANSI(true)
 	}
 
-	if to.Fg.ColorMode != from.Fg.ColorMode || to.Fg.Code != from.Fg.Code {
+	differentFgCode := (to.Fg.ColorMode != ecma48.ColorNone || true) && to.Fg.Code != from.Fg.Code
+	if to.Fg.ColorMode != from.Fg.ColorMode || differentFgCode {
 		out += to.Fg.ToANSI(false)
 	}
 

--- a/render/cursor.go
+++ b/render/cursor.go
@@ -26,12 +26,12 @@ func deltaMarkup(fromCur, toCur ecma48.Cursor) string {
 	to := toCur.Style
 	from := fromCur.Style
 
-	differentBgCode := (to.Bg.ColorMode != ecma48.ColorNone || true) && to.Bg.Code != from.Bg.Code
+	differentBgCode := (to.Bg.ColorMode != ecma48.ColorNone) && to.Bg.Code != from.Bg.Code
 	if to.Bg.ColorMode != from.Bg.ColorMode || differentBgCode {
 		out += to.Bg.ToANSI(true)
 	}
 
-	differentFgCode := (to.Fg.ColorMode != ecma48.ColorNone || true) && to.Fg.Code != from.Fg.Code
+	differentFgCode := (to.Fg.ColorMode != ecma48.ColorNone) && to.Fg.Code != from.Fg.Code
 	if to.Fg.ColorMode != from.Fg.ColorMode || differentFgCode {
 		out += to.Fg.ToANSI(false)
 	}


### PR DESCRIPTION
ColorNone means that the default colors should be used, meaning Code is meaningless. Two ColorNones with different Codes are identical but previously were not treated as such, causing the renderer to very often (every 25 milliseconds) print reset color commands unnecessarily.

I bet this also means much less idle CPU usage, but I haven't tested this theory.