### PR TITLE
Write to stdout in chunks to prevent artifacts (and remove legacy code)

### DIFF
--- a/render/render.go
+++ b/render/render.go
@@ -111,13 +111,15 @@ func (r *Renderer) ListenToQueue() {
 		for {
 			fullyWritten := true
 			var diff strings.Builder
+		outer:
 			for y := 0; y <= r.h; y++ {
-				// some terminals truncate long stdout
-				if diff.Len() > 4000 {
-					fullyWritten = false
-					break
-				}
 				for x := 0; x < r.w; x++ {
+					// some terminals truncate long stdout
+					// 4000 to allow some extra chars to be added before crossing 4096
+					if diff.Len() > 4000 {
+						fullyWritten = false
+						break outer
+					}
 					r.writingMutex.Lock()
 					current := r.currentScreen[y][x]
 					pending := r.pendingScreen[y][x]


### PR DESCRIPTION
Some terminals (e.g. Alacritty) truncate stdout that's too long. 3mux thought text was being rendered when it was not, causing things to go out-of-sync. This commit fixes many artifacts, previously common when clearing the entire screen.

This also removes some legacy code.
