### PR TITLE
optimise rendering latency and efficiency

### DIFF
--- a/ecma48/renderer.go
+++ b/ecma48/renderer.go
@@ -47,4 +47,8 @@ func (s *Style) Reset() {
 
 	s.Fg.ColorMode = ColorNone
 	s.Bg.ColorMode = ColorNone
+
+	// Resetting the codes makes styles easier to compare
+	s.Fg.Code = 0
+	s.Bg.Code = 0
 }

--- a/render/render.go
+++ b/render/render.go
@@ -302,8 +302,8 @@ func (r *Renderer) UpdateOut(out int) {
 
 // HardRefresh force clears all cached chars. Used for handling terminal resize
 func (r *Renderer) HardRefresh() {
-	r.Write([]byte("\033[2J"))
 	r.Write([]byte("\033[0m"))
+	r.Write([]byte("\033[2J"))
 	r.Write([]byte("\033[H"))
 	r.drawingCursor = ecma48.Cursor{}
 	r.currentScreen = expandBuffer([][]ecma48.StyledChar{}, r.w, r.h)

--- a/render/render.go
+++ b/render/render.go
@@ -3,15 +3,23 @@ package render
 import (
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
 	"github.com/aaronjanse/3mux/ecma48"
 )
 
+// This is arbitrarily chosen. Once we reach two thirds of this, we switch to frame-based rendering
+const queueBufferSize = 4000
+
 // Renderer is our simplified implemention of ncurses
 type Renderer struct {
 	w, h int
+
+	renderMode uint32 // 0 for queue mode, 1 for frame mode
+
+	charQueue chan ecma48.PositionedChar
 
 	writingMutex  *sync.Mutex
 	pendingScreen [][]ecma48.StyledChar
@@ -33,6 +41,8 @@ type Renderer struct {
 // NewRenderer returns an initialized Renderer
 func NewRenderer(out int) *Renderer {
 	return &Renderer{
+		renderMode:    0,
+		charQueue:     make(chan ecma48.PositionedChar, queueBufferSize),
 		writingMutex:  &sync.Mutex{},
 		currentScreen: [][]ecma48.StyledChar{},
 		pendingScreen: [][]ecma48.StyledChar{},
@@ -79,25 +89,25 @@ func expandBuffer(buffer [][]ecma48.StyledChar, w, h int) [][]ecma48.StyledChar 
 
 // HandleCh places a PositionedChar in the pending screen buffer
 func (r *Renderer) HandleCh(ch ecma48.PositionedChar) {
-	if ch.Y < 0 || ch.Y >= len(r.pendingScreen) {
+	if ch.Y < 0 || ch.X < 0 || ch.Y > r.h || ch.X > r.w {
 		return
 	}
-	if ch.X < 0 || ch.X >= len(r.pendingScreen[ch.Y]) {
-		return
-	}
-
-	r.writingMutex.Lock()
 	if ch.Rune == 0 {
 		ch.Rune = ' '
 	}
 
-	r.pendingScreen[ch.Y][ch.X] = ecma48.StyledChar{
-		Rune:     ch.Rune,
-		IsWide:   ch.IsWide,
-		PrevWide: ch.PrevWide,
-		Style:    ch.Cursor.Style,
+	if atomic.LoadUint32(&r.renderMode) == 0 { // queue mode
+		r.charQueue <- ch
+	} else { // frame mode
+		r.writingMutex.Lock()
+		r.pendingScreen[ch.Y][ch.X] = ecma48.StyledChar{
+			Rune:     ch.Rune,
+			IsWide:   ch.IsWide,
+			PrevWide: ch.PrevWide,
+			Style:    ch.Cursor.Style,
+		}
+		r.writingMutex.Unlock()
 	}
-	r.writingMutex.Unlock()
 }
 
 // DemoKeypress is used for demos of 3mux
@@ -105,59 +115,88 @@ func (r *Renderer) DemoKeypress(str string) {
 
 }
 
-// ListenToQueue is a blocking function that processes data sent to the RenderQueue
-func (r *Renderer) ListenToQueue() {
+func (r *Renderer) Render() {
 	for {
-		for {
-			fullyWritten := true
-			var diff strings.Builder
-		outer:
-			for y := 0; y <= r.h; y++ {
-				for x := 0; x < r.w; x++ {
-					// some terminals truncate long stdout
-					// 4000 to allow some extra chars to be added before crossing 4096
-					if diff.Len() > 4000 {
-						fullyWritten = false
-						break outer
-					}
-					r.writingMutex.Lock()
-					current := r.currentScreen[y][x]
-					pending := r.pendingScreen[y][x]
-					if current != pending {
-						r.currentScreen[y][x] = pending
+		r.RenderViaQueue()
+		r.RenderViaFrames()
+	}
+}
 
-						if !pending.PrevWide {
-							newCursor := ecma48.Cursor{
-								X: x, Y: y, Style: pending.Style,
-							}
+// RenderViaQueue displays characters immediately after they are sent to
+// HandleCh. This rendering mode has lowest latency but can "fall behind"
+// when panes are outputting characters faster than the host terminal will
+// accept them. Exits during high load.
+func (r *Renderer) RenderViaQueue() {
+	for {
+		select {
+		case <-r.Pause:
+			<-r.Resume
+		case posCh := <-r.charQueue:
+			if posCh.Rune == 0 {
+				r.restingCursor = ecma48.Cursor{X: posCh.X, Y: posCh.Y, Style: r.restingCursor.Style}
+			} else {
+				pendingCh := ecma48.StyledChar{
+					Rune:     posCh.Rune,
+					IsWide:   posCh.IsWide,
+					PrevWide: posCh.PrevWide,
+					Style:    posCh.Cursor.Style,
+				}
+				if r.currentScreen[posCh.Y][posCh.X] == pendingCh {
+					continue
+				}
+				r.currentScreen[posCh.Y][posCh.X] = pendingCh
 
-							delta := deltaMarkup(r.drawingCursor, newCursor)
-							diff.WriteString(delta)
-							diff.WriteString(string(pending.Rune))
-
-							if pending.IsWide {
-								newCursor.X += 2
-							} else {
-								newCursor.X++
-							}
-
-							r.drawingCursor = newCursor
-						}
-					}
-					r.writingMutex.Unlock()
+				delta := deltaMarkup(r.drawingCursor, posCh.Cursor) + string(posCh.Rune)
+				r.Write([]byte(delta))
+				r.drawingCursor = posCh.Cursor
+				if posCh.IsWide {
+					r.drawingCursor.X += 2
+				} else {
+					r.drawingCursor.X++
 				}
 			}
+			delta := deltaMarkup(r.drawingCursor, r.restingCursor)
+			r.Write([]byte(delta))
+			r.drawingCursor = r.restingCursor
 
-			diffStr := diff.String()
-			if len(diffStr) > 0 {
-				diffBytes := []byte(diffStr)
-				r.Write(diffBytes)
-			}
-
-			if fullyWritten {
-				break
+			// log.Println("# Queue length:", len(r.charQueue))
+			if len(r.charQueue) > (queueBufferSize*2)/3 {
+				r.writingMutex.Lock()
+				atomic.StoreUint32(&r.renderMode, 1)
+				for y := 0; y <= r.h; y++ {
+					copy(r.pendingScreen[y], r.currentScreen[y])
+				}
+				for posCh := range r.charQueue {
+					r.pendingScreen[posCh.Y][posCh.X] = ecma48.StyledChar{
+						Rune:     posCh.Rune,
+						IsWide:   posCh.IsWide,
+						PrevWide: posCh.PrevWide,
+						Style:    posCh.Cursor.Style,
+					}
+					if len(r.charQueue) == 0 {
+						break
+					}
+				}
+				r.writingMutex.Unlock()
+				return
 			}
 		}
+	}
+}
+
+// RenderViaFrames sets a framerate at which it writes all new characters.
+// This is best during high load, such as dumping a file to stdout, where
+// the renderer can quickly show the final display state instead of slowly
+// scrolling to get there. Exits during low load.
+func (r *Renderer) RenderViaFrames() {
+	numEmptyFrames := 0
+	const numEmptyFramesTillExit = 10
+	for {
+		if numEmptyFrames >= numEmptyFramesTillExit {
+			atomic.StoreUint32(&r.renderMode, 0)
+		}
+
+		emptyFrame := r.RenderSingleFrame()
 
 		if r.drawingCursor != r.restingCursor {
 			delta := deltaMarkup(r.drawingCursor, r.restingCursor)
@@ -165,7 +204,17 @@ func (r *Renderer) ListenToQueue() {
 			r.drawingCursor = r.restingCursor
 		}
 
-		// thr delay frees up the CPU for an arbitrary amount of time
+		if numEmptyFrames >= numEmptyFramesTillExit {
+			break
+		}
+
+		if emptyFrame {
+			numEmptyFrames++
+		} else {
+			numEmptyFrames = 0
+		}
+
+		// this delay frees up the CPU for an arbitrary amount of time
 		timer := time.NewTimer(time.Millisecond * 25)
 
 		select {
@@ -173,16 +222,74 @@ func (r *Renderer) ListenToQueue() {
 			timer.Stop()
 		case <-r.Pause:
 			<-r.Resume
-			// fmt.Print("\033[0;0H\033[0m") // reset real cursor
-			// r.drawingCursor = Cursor{}    // reset virtual cursor
 		}
 	}
 }
 
+func (r *Renderer) RenderSingleFrame() bool {
+	emptyFrame := true
+	for {
+		fullyWritten := true
+		var diff strings.Builder
+	outer:
+		for y := 0; y <= r.h; y++ {
+			for x := 0; x < r.w; x++ {
+				// some terminals truncate long stdout
+				// 4000 to allow some extra chars to be added before crossing 4096
+				if diff.Len() > 4000 {
+					fullyWritten = false
+					break outer
+				}
+				r.writingMutex.Lock()
+				current := r.currentScreen[y][x]
+				pending := r.pendingScreen[y][x]
+				if current != pending {
+					r.currentScreen[y][x] = pending
+
+					if !pending.PrevWide {
+						newCursor := ecma48.Cursor{
+							X: x, Y: y, Style: pending.Style,
+						}
+
+						delta := deltaMarkup(r.drawingCursor, newCursor)
+						diff.WriteString(delta)
+						diff.WriteString(string(pending.Rune))
+
+						if pending.IsWide {
+							newCursor.X += 2
+						} else {
+							newCursor.X++
+						}
+
+						r.drawingCursor = newCursor
+					}
+				}
+				r.writingMutex.Unlock()
+			}
+		}
+
+		diffStr := diff.String()
+		if len(diffStr) > 0 {
+			emptyFrame = false
+			diffBytes := []byte(diffStr)
+			// log.Println("Writing frame diff of length", len(diffBytes))
+			// log.Printf("Writing frame bytes: %q", diffBytes)
+			r.Write(diffBytes)
+		}
+
+		if fullyWritten {
+			break
+		}
+	}
+	return emptyFrame
+}
+
 // SetCursor sets the position of the physical cursor
 func (r *Renderer) SetCursor(x, y int) {
-	r.restingCursor = ecma48.Cursor{
-		X: x, Y: y, Style: r.drawingCursor.Style,
+	if atomic.LoadUint32(&r.renderMode) == 0 { // queue mode
+		r.charQueue <- ecma48.PositionedChar{Cursor: ecma48.Cursor{X: x, Y: y}}
+	} else { // frame mode
+		r.restingCursor = ecma48.Cursor{X: x, Y: y, Style: r.restingCursor.Style}
 	}
 }
 
@@ -199,9 +306,7 @@ func (r *Renderer) HardRefresh() {
 	r.Write([]byte("\033[0m"))
 	r.Write([]byte("\033[H"))
 	r.drawingCursor = ecma48.Cursor{}
-	for y := range r.currentScreen {
-		for x := range r.currentScreen[y] {
-			r.currentScreen[y][x] = ecma48.StyledChar{}
-		}
-	}
+	r.currentScreen = expandBuffer([][]ecma48.StyledChar{}, r.w, r.h)
+
+	r.RenderSingleFrame()
 }

--- a/serve.go
+++ b/serve.go
@@ -25,7 +25,7 @@ func serve(sessionInfo *SessionInfo) error {
 
 	renderer := render.NewRenderer(-1)
 	renderer.Resize(20, 20)
-	go renderer.ListenToQueue()
+	go renderer.Render()
 
 	shutdown := make(chan error)
 

--- a/vterm/csi.go
+++ b/vterm/csi.go
@@ -10,19 +10,19 @@ func (v *VTerm) handleEraseInDisplay(directive int) {
 	switch directive {
 	case 0: // clear from Cursor to end of screen
 		for i := v.Cursor.X; i < len(v.Screen[v.Cursor.Y]); i++ {
-			v.setChar(i, v.Cursor.Y, ' ', v.Cursor.Style)
+			v.setChar(i, v.Cursor.Y, ' ')
 		}
 		if v.Cursor.Y+1 < len(v.Screen) {
 			for j := v.Cursor.Y + 1; j < len(v.Screen); j++ {
 				for i := 0; i < len(v.Screen[j]); i++ {
-					v.setChar(i, j, ' ', v.Cursor.Style)
+					v.setChar(i, j, ' ')
 				}
 			}
 		}
 	case 1: // clear from Cursor to beginning of screen
 		for j := 0; j < v.Cursor.Y; j++ {
 			for i := 0; i < len(v.Screen[j]); i++ {
-				v.setChar(i, j, ' ', v.Cursor.Style)
+				v.setChar(i, j, ' ')
 			}
 		}
 	case 2: // clear entire screen (and move Cursor to top left?)
@@ -35,7 +35,7 @@ func (v *VTerm) handleEraseInDisplay(directive int) {
 				v.Screen = append(v.Screen, newLine)
 			}
 			for j := range v.Screen[i] {
-				v.setChar(j, i, ' ', v.Cursor.Style)
+				v.setChar(j, i, ' ')
 			}
 		}
 		v.setCursorPos(0, 0)
@@ -43,7 +43,7 @@ func (v *VTerm) handleEraseInDisplay(directive int) {
 		v.Scrollback = [][]ecma48.StyledChar{}
 		for j := range v.Screen {
 			for i := range v.Screen[j] {
-				v.setChar(i, j, ' ', v.Cursor.Style)
+				v.setChar(i, j, ' ')
 			}
 		}
 		v.setCursorPos(0, 0)
@@ -71,6 +71,6 @@ func (v *VTerm) handleEraseInLine(directive int) {
 	}
 
 	for i := min; i < max; i++ {
-		v.setChar(i, v.Cursor.Y, ' ', v.Cursor.Style)
+		v.setChar(i, v.Cursor.Y, ' ')
 	}
 }

--- a/vterm/ops.go
+++ b/vterm/ops.go
@@ -160,14 +160,14 @@ func (v *VTerm) shiftCursorY(diff int) {
 	v.setCursorPos(v.Cursor.X, v.Cursor.Y+diff)
 }
 
-func (v *VTerm) setChar(x, y int, r rune, style ecma48.Style) {
+func (v *VTerm) setChar(x, y int, r rune) {
 	if x >= v.w {
 		return
 	}
-	v.Screen[y][x] = ecma48.StyledChar{Rune: r, Style: style}
+	v.Screen[y][x] = ecma48.StyledChar{Rune: r, Style: v.Cursor.Style}
 	if !v.usingSlowRefresh {
 		v.renderer.HandleCh(ecma48.PositionedChar{
-			Cursor: ecma48.Cursor{X: x + v.x, Y: y + v.y, Style: style}, Rune: r,
+			Cursor: ecma48.Cursor{X: x + v.x, Y: y + v.y, Style: v.Cursor.Style}, Rune: r,
 		})
 	}
 }

--- a/vterm/ops.go
+++ b/vterm/ops.go
@@ -160,6 +160,18 @@ func (v *VTerm) shiftCursorY(diff int) {
 	v.setCursorPos(v.Cursor.X, v.Cursor.Y+diff)
 }
 
+func (v *VTerm) setChar(x, y int, r rune, style ecma48.Style) {
+	if x >= v.w {
+		return
+	}
+	v.Screen[y][x] = ecma48.StyledChar{Rune: r, Style: style}
+	if !v.usingSlowRefresh {
+		v.renderer.HandleCh(ecma48.PositionedChar{
+			Cursor: ecma48.Cursor{X: x + v.x, Y: y + v.y, Style: style}, Rune: r,
+		})
+	}
+}
+
 // putChar renders as given character using the cursor stored in vterm
 func (v *VTerm) putChar(ch rune, wide bool) {
 	var rWidth int

--- a/vterm/stdout.go
+++ b/vterm/stdout.go
@@ -69,7 +69,7 @@ func (v *VTerm) ProcessStdout(input *bufio.Reader) {
 				if v.Cursor.X > 0 {
 					v.shiftCursorX(-1)
 				}
-				v.RedrawWindow()
+				v.RefreshCursor()
 			case ecma48.Newline:
 				if v.Cursor.Y == v.scrollingRegion.bottom-1 {
 					v.scrollUp(1)

--- a/wm/draw-lines.go
+++ b/wm/draw-lines.go
@@ -26,6 +26,10 @@ func (s *split) getSelectedNode() Node {
 }
 
 func (u *Universe) drawSelectionBorder() {
+	// don't draw when there's only one pane
+	if len(u.workspaces[u.selectionIdx].contents.elements) == 1 {
+		return
+	}
 	maxH := u.workspaces[u.selectionIdx].contents.GetRenderRect().H
 
 	r := u.getSelectedNode().GetRenderRect()

--- a/wm/mouse.go
+++ b/wm/mouse.go
@@ -1,12 +1,16 @@
 package wm
 
 func (u *Universe) SelectAtCoords(x, y int) {
+	if u.workspaces[0].doFullscreen {
+		return
+	}
+
 	u.wmOpMutex.Lock()
 	defer u.wmOpMutex.Unlock()
 
 	u.workspaces[u.selectionIdx].selectAtCoords(x, y)
 	u.updateSelection()
-	u.refreshRenderRect() // FIXME only needs to redraw lines!
+	u.drawSelectionBorder()
 }
 
 func (s *workspace) selectAtCoords(x, y int) {
@@ -33,8 +37,13 @@ func (s *split) selectAtCoords(x, y int) {
 }
 
 func (u *Universe) DragBorder(x1, y1, x2, y2 int) {
+	if u.workspaces[u.selectionIdx].doFullscreen {
+		return
+	}
+
 	u.workspaces[u.selectionIdx].dragBorder(x1, y1, x2, y2)
-	u.refreshRenderRect() // FIXME only needs to redraw lines!
+	u.redrawAllLines()
+	u.drawSelectionBorder()
 }
 
 func (s *workspace) dragBorder(x1, y1, x2, y2 int) {
@@ -75,6 +84,7 @@ func (s *split) dragBorder(x1, y1, x2, y2 int) {
 
 			s.elements[idx].size = wantedBorderRatio * totalProportion
 			s.elements[idx+1].size = (1 - wantedBorderRatio) * totalProportion
+			s.refreshRenderRect(false)
 			return
 		}
 


### PR DESCRIPTION
On my laptop, this reduces idle CPU usage from 3% to 0%. It also reduces rendering latency in many cases.

Currently, the global renderer continually scans the entire `pendingScreen` to see if anything has changed, rendering frame-by-frame. In this PR, when the renderer detects a series of frames without changes, it uses a queue to render characters immediately once they're received. When the queue gets too long, the renderer switches back to frame-based rendering. This is similar to [how tmux works](https://github.com/tmux/tmux/issues/849#issuecomment-291828893). See the comments on `RenderViaQueue` and `RenderViaFrames` for more information.

In addition to optimizing the global renderer, I made some optimizations in `wm/` and `vterm/`. Without them, the global renderer has many "high-throughput mode" false-positives. If wanted, I could put these changes in a separate PR.