### PR TITLE
Fix tabulation in help

### DIFF
--- a/help.go
+++ b/help.go
@@ -10,18 +10,18 @@ const helpText = `3mux
 The terminal multiplexer inspired by i3
 
 USAGE:
-    3mux				Interactive 3mux interface
-    3mux ls             List session names (has alias '3mux ps')
-    3mux attach <name>  Attach to a session
-    3mux detach			Detach from the current session
-    3mux new <name>     Create a new session
-    3mux kill <name>    Kill a session
+    3mux		  Interactive 3mux interface
+    3mux ls		  List session names (has alias '3mux ps')
+    3mux attach <name>	  Attach to a session
+    3mux detach		  Detach from the current session
+    3mux new <name>	  Create a new session
+    3mux kill <name>	  Kill a session
 
 SHORTCUTS:
-	Alt+N/Alt+Enter  Create new pane
-	Alt+Shift+Q		 Close pane
-	Alt+Shift+F		 Make pane fullscreen
-	Alt+Shift+Arrow	 Move pane
-	Alt+Arrow	     Move selection
-	Alt+/	         Toggle search
+	Alt+N/Alt+Enter	  Create new pane
+	Alt+Shift+Q	  Close pane
+	Alt+Shift+F	  Make pane fullscreen
+	Alt+Shift+Arrow	  Move pane
+	Alt+Arrow	  Move selection
+	Alt+/		  Toggle search
 `

--- a/help.go
+++ b/help.go
@@ -10,18 +10,18 @@ const helpText = `3mux
 The terminal multiplexer inspired by i3
 
 USAGE:
-    3mux		  Interactive 3mux interface
-    3mux ls		  List session names (has alias '3mux ps')
-    3mux attach <name>	  Attach to a session
-    3mux detach		  Detach from the current session
-    3mux new <name>	  Create a new session
-    3mux kill <name>	  Kill a session
+    3mux                  Interactive 3mux interface
+    3mux ls               List session names (has alias '3mux ps')
+    3mux attach <name>    Attach to a session
+    3mux detach           Detach from the current session
+    3mux new <name>       Create a new session
+    3mux kill <name>      Kill a session
 
 SHORTCUTS:
-	Alt+N/Alt+Enter	  Create new pane
-	Alt+Shift+Q	  Close pane
-	Alt+Shift+F	  Make pane fullscreen
-	Alt+Shift+Arrow	  Move pane
-	Alt+Arrow	  Move selection
-	Alt+/		  Toggle search
+	Alt+N/Alt+Enter   Create new pane
+	Alt+Shift+Q       Close pane
+	Alt+Shift+F       Make pane fullscreen
+	Alt+Shift+Arrow   Move pane
+	Alt+Arrow         Move selection
+	Alt+/             Toggle search
 `


### PR DESCRIPTION
Replaced usage of spaces with tabs (and 2 spaces afterwards) to format the help command.