### PR TITLE
add support for ecma48 ECH

### DIFF
--- a/ecma48/parsed.go
+++ b/ecma48/parsed.go
@@ -110,6 +110,11 @@ type EL struct {
 	Directive int
 }
 
+// ECH (Erase Characters)
+type ECH struct {
+	N int
+}
+
 // IL (Insert Lines)
 type IL struct {
 	N int

--- a/ecma48/parser.go
+++ b/ecma48/parser.go
@@ -455,6 +455,9 @@ func (p *Parser) dispatchCsi() {
 		case 'T': // Scroll Down; new lines added to top
 			seq := parseSemicolonNumSeq(p.params, 1)
 			p.out <- p.wrap(SD{N: uint(seq[0])}) // FIXME
+		case 'X':
+			seq := parseSemicolonNumSeq(p.params, 1)
+			p.out <- p.wrap(ECH{N: int(seq[0])})
 		// case 't': // Window Manipulation
 		// 	// TODO
 		case 'm': // Select Graphic Rendition

--- a/vterm/stdout.go
+++ b/vterm/stdout.go
@@ -104,16 +104,7 @@ func (v *VTerm) ProcessStdout(input *bufio.Reader) {
 					x.N = v.w - v.Cursor.X - 1
 				}
 				for i := 0; i < x.N; i++ {
-					x := v.Cursor.X + i
-					y := v.Cursor.Y
-					v.Screen[y][x] = ecma48.StyledChar{
-						Rune: ' ', IsWide: false, Style: v.Cursor.Style,
-					}
-					v.renderer.HandleCh(ecma48.PositionedChar{
-						Rune: ' ', IsWide: false, Cursor: ecma48.Cursor{
-							X: v.x + x, Y: v.y + y, Style: v.Cursor.Style,
-						},
-					})
+					v.setChar(v.Cursor.X+i, v.Cursor.Y, ' ')
 				}
 			case ecma48.DCH: // delete characters - like pressing the "delete" key
 				if x.N > v.w-v.Cursor.X {


### PR DESCRIPTION
This adds support for the [`ECH` code](https://vt100.net/docs/vt510-rm/ECH.html).

Compare the output of the following in a normal terminal and within 3mux before/after the fix:
```
echo -ne 'hiddenshown\r\e[6X\n'
```
