### PR TITLE
fix ecma48 cha implementation

### DIFF
--- a/vterm/stdout.go
+++ b/vterm/stdout.go
@@ -154,7 +154,7 @@ func (v *VTerm) ProcessStdout(input *bufio.Reader) {
 				v.shiftCursorY(-int(x.YDiff))
 				v.setCursorX(0)
 			case ecma48.CHA:
-				v.shiftCursorX(x.X)
+				v.setCursorX(x.X)
 			case ecma48.CUP:
 				v.setCursorPos(x.X, x.Y)
 			case ecma48.ED:


### PR DESCRIPTION
This fixes broken columns in htop and layout in kakoune.

See [docs for Cursor Horizontal Absolute](https://vt100.net/docs/vt510-rm/CHA.html).

Proof of concept:
```
echo -e '-> <-\e[3GX'
```