### PR TITLE
add flake.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ corpa.*
 todo
 *.sw*
 3mux
+result

--- a/README.md
+++ b/README.md
@@ -56,11 +56,18 @@
 2. `tar -zxvf YOUR_FILE.tar.gz`
 3. Add the now-extracted `./3mux` to your `$PATH`
 
+###### Using Nix flakes
+
+```
+nix run github:aaronjanse/3mux
+```
+
+
 ###### Package manager
 
 [![Packages for 3mux](https://repology.org/badge/vertical-allrepos/3mux.svg)](https://repology.org/project/3mux/versions)
 
-###### Via `go get`
+###### Building from source
 1. Install Golang
 2. `go get github.com/aaronjanse/3mux`
 3. Run `3mux` to launch the terminal multiplexer

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 2. `tar -zxvf YOUR_FILE.tar.gz`
 3. Add the now-extracted `./3mux` to your `$PATH`
 
-###### Using Nix flakes
+###### Using Nix flakes (requires Nix 2.4+)
 
 ```
 nix run github:aaronjanse/3mux

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1615107002,
+        "narHash": "sha256-7tNgNN9jG05JzlqYmU+JZmGaM0EREKDdF6mVa52IGIA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "63798f3cf053e77ac53ffaed270e628c1f4faa23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,6 @@
         ({ lib, buildGoModule, fetchFromGitHub }:
           buildGoModule rec {
             name = "3mux-latest";
-            execName = "3mux";
             src = ./.;
             vendorSha256 = "sha256-tbziQZIA1+b+ZtvA/865c8YQxn+r8HQy6Pqaac2kwcU=";
             excludedPackages = [ "fuzz" ];

--- a/flake.nix
+++ b/flake.nix
@@ -12,19 +12,10 @@
       });
       defaultPackage = forEachSystem (system: nixpkgs.legacyPackages."${system}".callPackage
         ({ lib, buildGoModule, fetchFromGitHub }:
-          let inherit (import
-            (fetchFromGitHub {
-              owner = "hercules-ci";
-              repo = "gitignore";
-              rev = "c4662e662462e7bf3c2a968483478a665d00e717";
-              sha256 = "sha256-nbZfz02QoVe1yYK7EtCV7wMi4VdHzZEoPg20ZSDo9to=";
-            })
-            { inherit lib; }) gitignoreSource;
-          in
           buildGoModule rec {
             name = "3mux-latest";
             execName = "3mux";
-            src = gitignoreSource ./.;
+            src = ./.;
             vendorSha256 = "sha256-tbziQZIA1+b+ZtvA/865c8YQxn+r8HQy6Pqaac2kwcU=";
             excludedPackages = [ "fuzz" ];
             meta = with lib; {

--- a/flake.nix
+++ b/flake.nix
@@ -11,12 +11,16 @@
         program = "${self.defaultPackage."${system}"}/bin/3mux";
       });
       defaultPackage = forEachSystem (system: nixpkgs.legacyPackages."${system}".callPackage
-        ({ lib, buildGoModule, fetchFromGitHub }:
-          buildGoModule rec {
+        ({ lib, buildGoModule, makeWrapper, fetchFromGitHub }:
+          buildGoModule {
             name = "3mux-latest";
             src = ./.;
             vendorSha256 = "sha256-tbziQZIA1+b+ZtvA/865c8YQxn+r8HQy6Pqaac2kwcU=";
             excludedPackages = [ "fuzz" ];
+            buildInputs = [ makeWrapper ];
+            postInstall = ''
+              wrapProgram $out/bin/3mux --prefix PATH : $out/bin
+            '';
             meta = with lib; {
               description = "Terminal multiplexer inspired by i3";
               longDescription = ''

--- a/flake.nix
+++ b/flake.nix
@@ -26,8 +26,6 @@
               '';
               homepage = "https://github.com/aaronjanse/3mux";
               license = licenses.mit;
-              # Br1ght0ne co-maintains the Nix derivation in Nixpkgs
-              maintainers = with maintainers; [ aaronjanse ];
               platforms = platforms.unix;
             };
           }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  inputs.nixpkgs.url = "github:nixos/nixpkgs";
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      forEachSystem = func: nixpkgs.lib.genAttrs systems func;
+    in
+    {
+      defaultApp = forEachSystem (system: {
+        type = "app";
+        program = "${self.defaultPackage."${system}"}/bin/3mux";
+      });
+      defaultPackage = forEachSystem (system: nixpkgs.legacyPackages."${system}".callPackage
+        ({ lib, buildGoModule, fetchFromGitHub }:
+          let inherit (import
+            (fetchFromGitHub {
+              owner = "hercules-ci";
+              repo = "gitignore";
+              rev = "c4662e662462e7bf3c2a968483478a665d00e717";
+              sha256 = "sha256-nbZfz02QoVe1yYK7EtCV7wMi4VdHzZEoPg20ZSDo9to=";
+            })
+            { inherit lib; }) gitignoreSource;
+          in
+          buildGoModule rec {
+            name = "3mux-latest";
+            execName = "3mux";
+            src = gitignoreSource ./.;
+            vendorSha256 = "sha256-tbziQZIA1+b+ZtvA/865c8YQxn+r8HQy6Pqaac2kwcU=";
+            excludedPackages = [ "fuzz" ];
+            meta = with lib; {
+              description = "Terminal multiplexer inspired by i3";
+              longDescription = ''
+                3mux is a terminal multiplexer with out-of-the-box support for
+                search, mouse-controlled scrollback, and i3-like keybindings.
+              '';
+              homepage = "https://github.com/aaronjanse/3mux";
+              license = licenses.mit;
+              # Br1ght0ne co-maintains the Nix derivation in Nixpkgs
+              maintainers = with maintainers; [ aaronjanse ];
+              platforms = platforms.unix;
+            };
+          }
+        ) { }
+      );
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,0 @@
-with import <nixpkgs>{};
-stdenv.mkDerivation rec {
-    name = "multiplexer";
-    buildInputs =  [ autoreconfHook pkgconfig cmake ncurses go libtsm ];
-
-    GOPATH="/home/ajanse/.go";
-    GODEBUG="cgocheck=0";
-}


### PR DESCRIPTION
[Nix](https://nixos.org/) is a declarative package manager used [by myself](https://github.com/aaronjanse/dotfiles) and many of our users. This PR lets Nix users try 3mux by simply running:

```
nix run github:aaronjanse/3mux
```

This is made possible by replacing `shell.nix` with `flake.nix`, which supports some cool features in Nix 2.4 like the command above.

Sadly, to a non-Nix-user, the code in this PR is undecipherable. In the Nix world, the `flake.nix` added here is fairly standard, with `defaultPackage` specifying the default package (for `nix shell github:aaronjanse/3mux`) and `defaultApp` specifying the default executable (for `nix run github:aaronjanse/3mux`).

