### PR TITLE
fix wrapping at bottom of pane

### DIFF
--- a/vterm/ops.go
+++ b/vterm/ops.go
@@ -183,8 +183,10 @@ func (v *VTerm) putChar(ch rune, wide bool) {
 
 	if v.Cursor.X >= v.w-rWidth+1 {
 		v.setCursorX(0)
-		if v.Cursor.Y < v.scrollingRegion.bottom {
+		if v.Cursor.Y < v.scrollingRegion.bottom-1 {
 			v.shiftCursorY(1)
+		} else {
+			v.scrollUp(1)
 		}
 	}
 


### PR DESCRIPTION
By definition, we're at the bottom of the scrolling region when `v.Cursor.Y == v.scrollingRegion.bottom - 1`:
https://github.com/aaronjanse/3mux/blob/e2945b0b554cf4af8a7eb409f800ec8dd89a9039/vterm/vterm.go#L16-L17

This fixes related off-by-one error. It also tells 3mux to scroll when wrapping at the bottom right corner of a scrolling region.

Test case, when run in a shell with a prompt at the bottom of a pane:
```
seq 1 1 100 | paste -s -d+
```