### PR TITLE
clear help bar when disabled

### DIFF
--- a/wm/universe.go
+++ b/wm/universe.go
@@ -206,6 +206,15 @@ func (u *Universe) HideHelpBar() {
 	defer u.wmOpMutex.Unlock()
 
 	u.helpBar = false
+	for i := 0; i < u.renderRect.W; i++ {
+		u.renderer.HandleCh(ecma48.PositionedChar{
+			Rune: ' ',
+			Cursor: ecma48.Cursor{
+				X: i, Y: u.renderRect.H - 2,
+				Style: ecma48.Style{},
+			},
+		})
+	}
 	u.refreshRenderRect()
 }
 


### PR DESCRIPTION
Since the pane render area does not include the help bar line, the help bar wasn't being cleared when disabled via a shortcut.

To test this PR:
```
rm ~/.config/3mux/config.toml
go run *.go
```

Then type Alt+\ to disable the help bar. Observe that this PR immediately makes the help bar hidden after doing that shortcut.