### PR TITLE
verify y value in setChar

### DIFF
--- a/vterm/ops.go
+++ b/vterm/ops.go
@@ -164,6 +164,9 @@ func (v *VTerm) setChar(x, y int, r rune) {
 	if x >= v.w {
 		return
 	}
+	if y >= v.h {
+		return
+	}
 	v.Screen[y][x] = ecma48.StyledChar{Rune: r, Style: v.Cursor.Style}
 	if !v.usingSlowRefresh {
 		v.renderer.HandleCh(ecma48.PositionedChar{


### PR DESCRIPTION
Test case:
1. Create two panes, one above the other
2. Move to the top pane
3. Ensure you're using `zsh` (for consistency, since different shells do different things at the end of program output)
4. Run `seq 1 100`
5. Observe that after this PR, the top pane's bottom border is not erased

In the future, we should figure out what's calling setChar with unwanted parameters, but even in such a scenario, we don't want to present the user with broken rendering.