### PR TITLE
fix: correct typo "occured" → "occurred" in error log messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func main() {
 
 		child, err := daemonContext.Reborn()
 		if err != nil {
-			log.Println("Error occured while serving session daemon:", err)
+			log.Println("Error occurred while serving session daemon:", err)
 			os.Exit(1)
 		}
 		if child != nil {
@@ -168,7 +168,7 @@ func main() {
 		}
 		child, err := daemonContext.Reborn()
 		if err != nil {
-			fmt.Println("Error occured while spawning session daemon:", err)
+			fmt.Println("Error occurred while spawning session daemon:", err)
 			os.Exit(1)
 		}
 		if child == nil {


### PR DESCRIPTION
Two user-visible error log strings in `main.go` (lines 118 & 171) had "occured" instead of "occurred". No behavior change.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/aaronjanse/3mux/pull/130?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/aaronjanse/3mux/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->