### PR TITLE
fix: correct sucessfully→successfully typo in kill session message

### DIFF
--- a/main.go
+++ b/main.go
@@ -234,7 +234,7 @@ func main() {
 			fmt.Printf("Please also report this to %s\n", BUG_REPORT_URL)
 			os.Exit(1)
 		}
-		fmt.Println("Session sucessfully killed.")
+		fmt.Println("Session successfully killed.")
 	case "ls", "ps":
 		children, err := ioutil.ReadDir(threemuxDir)
 		if err != nil {


### PR DESCRIPTION
Fixes a simple typo in main.go where 'sucessfully' should be 'successfully' in the kill session confirmation message.

**Before:** `fmt.Println("Session sucessfully killed.")`
**After:** `fmt.Println("Session successfully killed.")`

1 line change. 1 commit.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/aaronjanse/3mux/pull/131?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/aaronjanse/3mux/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->